### PR TITLE
update s3 region domains

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -26,7 +26,7 @@ For production, you will also need to set:
 * CALLPOWER_CONFIG='call_server.config:ProductionConfig', so that manager.py knows to use a real database for migrations
 * DATABASE_URI, a sqlalchemy [connection string](https://pythonhosted.org/Flask-SQLAlchemy/config.html#connection-uri-format) for a postgres or mysql database addresses
 * REDIS_URL, a URI for the Redis server
-* APPLICATION_ROOT to the path where the application will live. If you are using a whole domain or subdomain, this does not need to be defined.
+* APPLICATION_ROOT to the path where the application will live. If you are using a whole domain or subdomain, this *SHOULD NOT* be defined. Otherwise, it will mess up cookie handling and cause CSRF 400 errors on login.
 
 If you are storing assets on Amazon S3, or another [Flask-Store provider](http://flask-store.soon.build)
 

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -32,6 +32,7 @@ If you are storing assets on Amazon S3, or another [Flask-Store provider](http:/
 
 * STORE_S3_BUCKET
 * STORE_S3_REGION (eg: us-east-1, or us-west-2)
+* STORE_DOMAIN (automatically set by S3 region and bucket, override if you are using another provider)
 * S3_ACCESS_KEY
 * S3_SECRET_KEY
 

--- a/call_server/config.py
+++ b/call_server/config.py
@@ -88,7 +88,14 @@ class ProductionConfig(DefaultConfig):
     STORE_S3_REGION = os.environ.get('STORE_S3_REGION')
     STORE_S3_ACCESS_KEY = os.environ.get('S3_ACCESS_KEY')
     STORE_S3_SECRET_KEY = os.environ.get('S3_SECRET_KEY')
-    STORE_DOMAIN = 'https://%s.s3-%s.amazonaws.com/' % (STORE_S3_BUCKET, STORE_S3_REGION)
+    STORE_DOMAIN = os.environ.get('STORE_DOMAIN')
+    if not STORE_DOMAIN and STORE_S3_REGION:
+        # set external store domain per AWS regions
+        # http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
+        if STORE_S3_REGION is 'us-east-1':
+            STORE_DOMAIN = 'https://%s.s3.amazonaws.com/' % (STORE_S3_BUCKET)
+        else:
+            STORE_DOMAIN = 'https://%s.s3-%s.amazonaws.com/' % (STORE_S3_BUCKET, STORE_S3_REGION)
 
 
 class HerokuConfig(ProductionConfig):


### PR DESCRIPTION
Turns out buckets in the us-east-1 region do not respond to access via s3-us-east-1.amazonaws.com, but instead just as s3.amazonaws.com. Update config setting and documentation.
